### PR TITLE
feat: 주간 챌린지 랭킹 조회 기능 및 DB 테이블 구현

### DIFF
--- a/sql/challenge_ranking.sql
+++ b/sql/challenge_ranking.sql
@@ -1,0 +1,10 @@
+CREATE TABLE challenge_ranking (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    score INT NOT NULL,
+    ranking INT NOT NULL,
+    recorded_date DATE NOT NULL, -- 예: 2025-05-20
+
+    CONSTRAINT fk_challenge_ranking_user FOREIGN KEY (user_id) REFERENCES users(id),
+    UNIQUE KEY uq_user_date (user_id, recorded_date) -- 한 유저가 같은 주에 중복 기록되지 않도록
+);

--- a/src/main/java/com/balanceeat/demo/config/SecurityConfig.java
+++ b/src/main/java/com/balanceeat/demo/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
 			authorizeCustomizer -> authorizeCustomizer
 				.requestMatchers(antMatcher("/h2-console/**")).permitAll()
 				.requestMatchers(antMatcher("/auth/**")).permitAll()
+				.requestMatchers(antMatcher("/auth/reissue")).permitAll()
 				.requestMatchers(antMatcher("/api/auth/**")).permitAll()
 				.requestMatchers(antMatcher("/swagger-ui/**")).permitAll()
 				.requestMatchers(antMatcher("/v3/api-docs/**")).permitAll()

--- a/src/main/java/com/balanceeat/demo/domain/challenge/controller/ChallengeRankingController.java
+++ b/src/main/java/com/balanceeat/demo/domain/challenge/controller/ChallengeRankingController.java
@@ -1,0 +1,31 @@
+package com.balanceeat.demo.domain.challenge.controller;
+
+import com.balanceeat.demo.domain.auth.UserPrincipal;
+import com.balanceeat.demo.domain.challenge.dto.ChallengeRankingResponseDto;
+import com.balanceeat.demo.domain.challenge.service.ChallengeRankingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/challenge/ranking")
+@RequiredArgsConstructor
+@Tag(name = "Challenge Ranking API", description = "챌린지 랭킹 조회 API")
+public class ChallengeRankingController {
+
+    private final ChallengeRankingService rankingService;
+
+    @GetMapping
+    @Operation(summary = "챌린지 랭킹 조회", description = "상위 10명과 내 랭킹 반환")
+    public ResponseEntity<ChallengeRankingResponseDto> getWeeklyRankings(
+            @AuthenticationPrincipal UserPrincipal user) {
+
+        Long id = user.getId();
+        ChallengeRankingResponseDto response = rankingService.getWeeklyRankingsWithMyRank(id);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/balanceeat/demo/domain/challenge/dto/ChallengeRankDto.java
+++ b/src/main/java/com/balanceeat/demo/domain/challenge/dto/ChallengeRankDto.java
@@ -1,0 +1,18 @@
+// Top 10 User나 내 순위를 담을 수 있는 DTO
+// ChallengeRanking + User + UserChallengeProfile 에서 합쳐진 정보
+
+package com.balanceeat.demo.domain.challenge.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder(toBuilder = true)
+public class ChallengeRankDto {
+
+    private int ranking;               // 순위
+    private Long userId;              // 유저 ID (프로필 이동용)
+    private String nickname;          // 유저 닉네임
+    private String profileImageUrl;   // 프로필 이미지
+    private int score;                // 점수
+}

--- a/src/main/java/com/balanceeat/demo/domain/challenge/dto/ChallengeRankingResponseDto.java
+++ b/src/main/java/com/balanceeat/demo/domain/challenge/dto/ChallengeRankingResponseDto.java
@@ -1,0 +1,13 @@
+package com.balanceeat.demo.domain.challenge.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class ChallengeRankingResponseDto {
+    private List<ChallengeRankDto> topRankers; // Top 10
+    private ChallengeRankDto myRank; // 내 순위
+}

--- a/src/main/java/com/balanceeat/demo/domain/challenge/entity/ChallengeRanking.java
+++ b/src/main/java/com/balanceeat/demo/domain/challenge/entity/ChallengeRanking.java
@@ -1,0 +1,20 @@
+package com.balanceeat.demo.domain.challenge.entity;
+
+import lombok.Data;
+import java.time.LocalDate;
+
+@Data
+public class ChallengeRanking {
+
+    private Long id;            // PK (자동 증가)
+    private Long userId;        // 유저 ID (FK)
+
+    private int score;          // 챌린지 점수
+    private int ranking;           // 해당 주차의 순위
+
+    private LocalDate recordedDate; // 랭킹이 기록된 날짜 (주차 구분)
+
+    // 아래는 조인용 필드 (선택)
+    private String nickname;          // User 테이블에서 조인
+    private String profileImageUrl;   // UserChallengeProfile 테이블에서 조인
+}

--- a/src/main/java/com/balanceeat/demo/domain/challenge/mapper/ChallengeRankingMapper.java
+++ b/src/main/java/com/balanceeat/demo/domain/challenge/mapper/ChallengeRankingMapper.java
@@ -1,0 +1,18 @@
+package com.balanceeat.demo.domain.challenge.mapper;
+
+import com.balanceeat.demo.domain.challenge.dto.ChallengeRankDto;
+import com.balanceeat.demo.domain.challenge.entity.ChallengeRanking;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Mapper
+public interface ChallengeRankingMapper {
+
+    List<ChallengeRankDto> getTopRankings(@Param("recordedDate") LocalDate recordedDate);
+
+    ChallengeRankDto getMyRanking(@Param("recordedDate") LocalDate recordedDate,
+                                  @Param("userId") Long userId);
+}

--- a/src/main/java/com/balanceeat/demo/domain/challenge/service/ChallengeRankingService.java
+++ b/src/main/java/com/balanceeat/demo/domain/challenge/service/ChallengeRankingService.java
@@ -1,0 +1,7 @@
+package com.balanceeat.demo.domain.challenge.service;
+
+import com.balanceeat.demo.domain.challenge.dto.ChallengeRankingResponseDto;
+
+public interface ChallengeRankingService {
+    ChallengeRankingResponseDto getWeeklyRankingsWithMyRank(Long id);
+}

--- a/src/main/java/com/balanceeat/demo/domain/challenge/service/ChallengeRankingServiceImpl.java
+++ b/src/main/java/com/balanceeat/demo/domain/challenge/service/ChallengeRankingServiceImpl.java
@@ -1,0 +1,40 @@
+package com.balanceeat.demo.domain.challenge.service;
+
+import com.balanceeat.demo.domain.challenge.dto.ChallengeRankDto;
+import com.balanceeat.demo.domain.challenge.dto.ChallengeRankingResponseDto;
+import com.balanceeat.demo.domain.challenge.mapper.ChallengeRankingMapper;
+import com.balanceeat.demo.exception.BusinessException;
+import com.balanceeat.demo.exception.ErrorMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeRankingServiceImpl implements ChallengeRankingService {
+
+    private final ChallengeRankingMapper rankingMapper;
+
+    @Override
+    public ChallengeRankingResponseDto getWeeklyRankingsWithMyRank(Long id) {
+        LocalDate now = LocalDate.now();
+
+        // 1. 이번 주 TOP 10
+        List<ChallengeRankDto> topRankings = rankingMapper.getTopRankings(now);
+        // 2. 내 랭킹
+        ChallengeRankDto myRanking = rankingMapper.getMyRanking(now, id);
+
+        if (myRanking == null) {
+            throw new BusinessException(ErrorMessage.USER_NOT_FOUND, HttpStatus.NOT_FOUND);
+        }
+
+        // 결과 반환
+        return ChallengeRankingResponseDto.builder()
+                .topRankers(topRankings)
+                .myRank(myRanking)
+                .build();
+    }
+}

--- a/src/main/resources/mapper/ChallengeRankingMapper.xml
+++ b/src/main/resources/mapper/ChallengeRankingMapper.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.balanceeat.demo.domain.challenge.mapper.ChallengeRankingMapper">
+
+    <!-- 상위 10명 랭킹 조회 -->
+    <select id="getTopRankings" parameterType="date" resultType="com.balanceeat.demo.domain.challenge.dto.ChallengeRankDto">
+        SELECT
+            r.user_id AS userId,
+            r.ranking,
+            r.score,
+            u.nickname,
+            u.profile_image_url AS profileImageUrl
+        FROM challenge_ranking r
+                 JOIN users u ON r.user_id = u.id
+        WHERE r.recorded_date = #{recordedDate}
+          AND u.is_active = true
+          AND u.is_challenge_enabled = true
+        ORDER BY r.ranking ASC
+        LIMIT 10
+    </select>
+
+    <!-- 내 랭킹 조회 -->
+    <select id="getMyRanking" resultType="com.balanceeat.demo.domain.challenge.dto.ChallengeRankDto">
+        SELECT
+            r.user_id AS userId,
+            r.ranking,
+            r.score,
+            u.nickname,
+            u.profile_image_url AS profileImageUrl
+        FROM challenge_ranking r
+                 JOIN users u ON r.user_id = u.id
+        WHERE r.recorded_date = #{recordedDate}
+          AND r.user_id = #{userId}
+          AND u.is_active = true
+    </select>
+</mapper>


### PR DESCRIPTION
- challenge_ranking 테이블 생성 (user_id, score, ranking, recorded_date)
- 챌린지 랭킹 Controller/Service/Mapper/DTO/Entity 구성
- 상위 10위 랭커 및 로그인한 유저의 랭킹 반환 API 구현
- JWT 인증 기반 사용자 식별 (UserPrincipal 사용)
- 중복 기록 방지를 위한 UNIQUE (user_id, recorded_date) 제약 조건 추가
- SecurityConfig에서 /auth/reissue 예외 처리 설정
- 사용자 미존재 시 예외 처리 적용 (BusinessException with USER_NOT_FOUND)

## 관련 이슈
closes #1