### PR TITLE
Feature#15 사용자 프로필 확장 및 회원 정보 수정 기능 개선

### DIFF
--- a/sql/users.sql
+++ b/sql/users.sql
@@ -8,6 +8,10 @@ CREATE TABLE users (
                        password VARCHAR(255) NOT NULL,
 
     -- 유저 정보
+                        profile_image_url VARCHAR(512),
+                        goal_message VARCHAR(255),
+                        is_challenge_enabled BOOLEAN DEFAULT TRUE,
+
                        nickname VARCHAR(50) NOT NULL,
                        birth_year INT NOT NULL,
                        gender ENUM('MALE', 'FEMALE', 'OTHER') NOT NULL,
@@ -25,4 +29,3 @@ CREATE TABLE users (
     -- 회원 탈퇴 여부
                        is_active BOOLEAN DEFAULT TRUE
 );
-

--- a/src/main/java/com/balanceeat/demo/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/balanceeat/demo/domain/auth/service/impl/AuthServiceImpl.java
@@ -98,9 +98,8 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public void login(LoginRequestDTO loginRequestDTO, HttpServletResponse httpServletResponse) {
         log.debug("로그인 처리 시작: {}", loginRequestDTO.getEmail());
-        User user = userMapper.findByEmail(loginRequestDTO.getEmail())
-            .orElseThrow(UserNotFoundException::new);
-        
+        User user = userService.findByEmail(loginRequestDTO.getEmail());
+
         if (!user.isActive()) {
             log.warn("로그인 실패 - 탈퇴한 회원: {}", loginRequestDTO.getEmail());
             throw new BusinessException(ErrorMessage.USER_ACCOUNT_DISABLED, HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/balanceeat/demo/domain/user/controller/UserController.java
+++ b/src/main/java/com/balanceeat/demo/domain/user/controller/UserController.java
@@ -1,57 +1,80 @@
 package com.balanceeat.demo.domain.user.controller;
 
 import com.balanceeat.demo.domain.user.dto.UserDTO;
+import com.balanceeat.demo.domain.user.dto.UserProfileDTO;
 import com.balanceeat.demo.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import org.yaml.snakeyaml.events.Event;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
-@Controller
+@RestController
+@RequiredArgsConstructor
 @RequestMapping("/user")
 public class UserController {
-    
-    @Autowired
-    private UserService userService;
-    
-    // 마이페이지 조회
-    @GetMapping("/mypage")
-    public String mypage(@SessionAttribute("user") Map<String, String> userInfo, Model model) {
-        String userId = userInfo.get("id");
-        UserDTO user = userService.getUserById(userId);
-        model.addAttribute("user", user);
-        return "user/mypage";
+    private static final Logger log = LoggerFactory.getLogger(UserController.class);
+
+    // 의존성 주입
+    private final UserService userService;
+
+    // 현재 로그인한 사용자의 프로필 정보 조회
+    @GetMapping("/profile")
+    public ResponseEntity<UserProfileDTO> getCurrentUserProfile(@AuthenticationPrincipal UserDetails userDetails) {
+        try {
+            if (userDetails == null) {
+                return ResponseEntity.status(401).build(); // Unauthorized
+            }
+            UserProfileDTO profile = userService.getCurrentUserProfile(userDetails);
+            return ResponseEntity.ok(profile);
+        } catch (Exception e) {
+            log.error("사용자 프로필 조회 중 오류 발생", e);
+            return ResponseEntity.status(500)
+                    .body(UserProfileDTO.builder()
+                            .id(null)
+                            .nickname("Error")
+                            .profileImageUrl(null)
+                            .goalMessage(e.getMessage())
+                            .build());
+        }
     }
-    
-    // 사용자 정보 수정 페이지
-    @GetMapping("/update")
-    public String updateForm(@SessionAttribute("user") Map<String, String> userInfo, Model model) {
-        String userId = userInfo.get("id");
-        UserDTO user = userService.getUserById(userId);
-        model.addAttribute("user", user);
-        return "user/updateUser";
+
+    // 사용자 정보 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<UserDTO> getUser(@PathVariable Long id) { // @PathVariable : URL 경로 안의 값을 메서드 파라미터로 바인딩해주는 어노테이션
+        return ResponseEntity.ok(userService.getUserById(id));
     }
-    
-    // 사용자 정보 수정 처리
-    @PostMapping("/update")
-    public String updateUser(@ModelAttribute UserDTO userDTO) {
-        userService.updateUser(userDTO);
-        return "redirect:/user/mypage";
+
+    // 특정 사용자의 프로필 정보 조회
+    @GetMapping("/{id}/profile")
+    public ResponseEntity<UserProfileDTO> getUserProfile(@PathVariable Long id) {
+        UserProfileDTO profile = userService.getUserProfile(id);
+        return ResponseEntity.ok(profile);
     }
-    
-    // 회원 탈퇴 페이지
-    @GetMapping("/delete")
-    public String deleteForm() {
-        return "user/deleteUser";
+
+    // 사용자 정보 수정
+    @PutMapping("/update")
+    public ResponseEntity<UserDTO> updateUser(@RequestBody UserDTO userDto, @AuthenticationPrincipal UserDetails userDetails) {
+        try {
+            UserDTO updatedUser = userService.updateUser(userDto, userDetails);
+            return ResponseEntity.ok(updatedUser);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
-    
-    // 회원 탈퇴 처리
-    @PostMapping("/delete")
-    public String deleteUser(@SessionAttribute("user") Map<String, String> userInfo) {
-        String userId = userInfo.get("id");
-        userService.deleteUser(userId);
-        return "redirect:/auth/logout";
+
+    // 사용자 탈퇴
+    @PutMapping("/{id}/deactivate")
+    public ResponseEntity<?> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.ok().build();
     }
 } 

--- a/src/main/java/com/balanceeat/demo/domain/user/dto/UserDTO.java
+++ b/src/main/java/com/balanceeat/demo/domain/user/dto/UserDTO.java
@@ -1,17 +1,23 @@
 package com.balanceeat.demo.domain.user.dto;
 
 import com.balanceeat.demo.domain.user.entity.User;
-
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class UserDTO {
-    private String id;
+    private Long id;
     private String email;
-    private String password;
-	
-	public static UserDTO from(User user) {
-        UserDTO userDTO = new UserDTO();
-        return userDTO;
-	}
+    private String currentPassword;
+    private String newPassword;
+    private String nickname;
+
+    public static UserDTO from(User user) {
+        UserDTO dto = new UserDTO();
+        dto.setId(user.getId());
+        dto.setEmail(user.getEmail());
+        dto.setNickname(user.getNickname());
+        return dto;
+    }
 }

--- a/src/main/java/com/balanceeat/demo/domain/user/dto/UserProfileDTO.java
+++ b/src/main/java/com/balanceeat/demo/domain/user/dto/UserProfileDTO.java
@@ -1,0 +1,16 @@
+package com.balanceeat.demo.domain.user.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileDTO {
+    private Long id;
+    private String email;
+    private String nickname;
+    private String profileImageUrl;
+    private String goalMessage;
+} 

--- a/src/main/java/com/balanceeat/demo/domain/user/entity/User.java
+++ b/src/main/java/com/balanceeat/demo/domain/user/entity/User.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +17,10 @@ public class User {
     private String password;
     
     // 유저 정보
+    private String profileImageUrl; // 프로필 사진
+    private String goalMessage; // 한 줄 목표
+    private boolean isChallengeEnabled; // 챌린지 참여 여부
+
     private String nickname;
     private int birthYear;
     private Gender gender;

--- a/src/main/java/com/balanceeat/demo/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/balanceeat/demo/domain/user/mapper/UserMapper.java
@@ -3,16 +3,17 @@ package com.balanceeat.demo.domain.user.mapper;
 import java.util.Optional;
 
 import com.balanceeat.demo.domain.user.dto.UserDTO;
+import com.balanceeat.demo.domain.user.dto.UserProfileDTO;
 import com.balanceeat.demo.domain.user.entity.User;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface UserMapper {
-    User getUserById(String id);
+    User getUserById(Long id);
+    UserProfileDTO getUserProfile(Long id);
     void updateUser(UserDTO userDTO);
-    void deleteUser(String id);
+    void deleteUser(Long id);
     Optional<User> findByEmail(String email);
     void insert(User user);
-    void updateUserIsActive(String id, boolean isActive);
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/balanceeat/demo/domain/user/service/UserService.java
+++ b/src/main/java/com/balanceeat/demo/domain/user/service/UserService.java
@@ -1,12 +1,16 @@
 package com.balanceeat.demo.domain.user.service;
 
 import com.balanceeat.demo.domain.user.dto.UserDTO;
+import com.balanceeat.demo.domain.user.dto.UserProfileDTO;
+import com.balanceeat.demo.domain.user.entity.User;
+import org.springframework.security.core.userdetails.UserDetails;
 
 public interface UserService {
-    UserDTO getUserById(String userId);
+    UserDTO getUserById(Long id);
     boolean existsByEmail(String email);
-    void updateUser(UserDTO userDTO);
-    void deleteUser(String userId);
-    
-    boolean findByEmail(String email);
+    User findByEmail(String email);
+    UserProfileDTO getUserProfile(Long id);
+    UserProfileDTO getCurrentUserProfile(UserDetails userDetails);
+    UserDTO updateUser(UserDTO userDto, UserDetails userDetails);
+    void deleteUser(Long id);
 }

--- a/src/main/java/com/balanceeat/demo/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/balanceeat/demo/domain/user/service/impl/UserServiceImpl.java
@@ -1,66 +1,107 @@
 package com.balanceeat.demo.domain.user.service.impl;
 
 import com.balanceeat.demo.domain.user.dto.UserDTO;
+import com.balanceeat.demo.domain.user.dto.UserProfileDTO;
 import com.balanceeat.demo.domain.user.entity.User;
 import com.balanceeat.demo.domain.user.exception.UserNotFoundException;
 import com.balanceeat.demo.domain.user.mapper.UserMapper;
 import com.balanceeat.demo.domain.user.service.UserService;
-import com.balanceeat.demo.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import com.balanceeat.demo.exception.auth.InvalidPasswordException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
-    
+
     private final UserMapper userMapper;
-    
+    private final PasswordEncoder passwordEncoder;
+
+    // 현재 로그인한 사용자의 프로필 정보 조회
     @Override
-    public UserDTO getUserById(String userId) {
-        log.debug("사용자 조회 시작: {}", userId);
-        User user = userMapper.getUserById(userId);
+    @Transactional(readOnly = true)
+    public UserProfileDTO getCurrentUserProfile(UserDetails userDetails) {
+        User user = findByEmail(userDetails.getUsername());
         if (user == null) {
-            log.warn("사용자를 찾을 수 없음: {}", userId);
             throw new UserNotFoundException();
         }
-        log.debug("사용자 조회 완료: {}", userId);
-        return UserDTO.from(user);
+        return getUserProfile(user.getId());
     }
-    
+
+    // 사용자 고유번호로 사용자 정보 조회
+    @Override
+    public UserDTO getUserById(Long id) { // 컨트롤러가 Json에서 받은 문자열 데이터를 @PathVariable 을 통해 long 타입으로 변환하여 전달하기 때문에 String 대신 Long 으로 작성
+        return UserDTO.from(userMapper.getUserById(id));
+    }
+
     @Override
     public boolean existsByEmail(String email) {
-        log.debug("사용자명 존재 여부 확인: {}", email);
-        boolean exists = userMapper.existsByEmail(email);
-        log.debug("사용자명 존재 여부 확인 결과: {} - {}", email, exists);
-        return exists;
+        return userMapper.existsByEmail(email);
     }
-    
+
+    // 사용자 이름 중복 확인 or 존재 확인 여부 체크
     @Override
-    public void updateUser(UserDTO userDTO) {
-        if (existsByEmail(userDTO.getEmail())) {
-            throw new BusinessException("동일한 아이디가 있습니다. 다른 아이디로 변경하세요", HttpStatus.BAD_REQUEST);
-        }
-        userMapper.updateUser(userDTO);
+    public User findByEmail(String email) {
+        return userMapper.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
     }
-    
+
     @Override
-    public void deleteUser(String userId) {
-    
-    }
-    
-    @Override
-    public boolean findByEmail(String email) {
-        log.debug("사용자명으로 조회 시작: {}", email);
-        User user = userMapper.findByEmail(email)
-            .orElseThrow(UserNotFoundException::new);
-        if (user == null) {
-            log.warn("사용자를 찾을 수 없음: {}", email);
+    public UserProfileDTO getUserProfile(Long id) {
+        UserProfileDTO profile = userMapper.getUserProfile(id);
+        if (profile == null) {
             throw new UserNotFoundException();
         }
-        log.debug("사용자명으로 조회 완료: {}", email);
-        return true;
+        return profile;
+    }
+
+    // 사용자 정보 수정
+    @Override
+    @Transactional
+    public UserDTO updateUser(UserDTO userDto, UserDetails userDetails) {
+        log.debug("회원 정보 수정 시작: email={}, nickname={}", userDetails.getUsername(), userDto.getNickname());
+        
+        User currentUser = findByEmail(userDetails.getUsername());
+        if(currentUser == null || !currentUser.isActive()) {
+            log.warn("사용자를 찾을 수 없거나 비활성화된 계정입니다: {}", userDetails.getUsername());
+            throw new UserNotFoundException();
+        }
+        
+        // 현재 비밀번호 검증
+        log.debug("현재 비밀번호 검증 시작");
+        if (!passwordEncoder.matches(userDto.getCurrentPassword(), currentUser.getPassword())) {
+            log.warn("비밀번호가 일치하지 않습니다: {}", userDetails.getUsername());
+            throw new InvalidPasswordException("현재 비밀번호가 일치하지 않습니다.");
+        }
+        log.debug("현재 비밀번호 검증 성공");
+
+        // 현재 로그인한 사용자의 정보만 수정 가능
+        userDto.setId(currentUser.getId());
+        
+        // 새 비밀번호가 있는 경우에만 비밀번호 업데이트
+        if (userDto.getNewPassword() != null && !userDto.getNewPassword().isEmpty()) {
+            log.debug("새 비밀번호 업데이트");
+            userDto.setNewPassword(passwordEncoder.encode(userDto.getNewPassword()));
+        }
+        
+        log.debug("회원 정보 업데이트 시작: id={}, nickname={}", userDto.getId(), userDto.getNickname());
+        userMapper.updateUser(userDto);
+        log.debug("회원 정보 업데이트 완료");
+        
+        return getUserById(currentUser.getId());
+    }
+
+    @Override
+    public void deleteUser(Long id) {
+        User user = userMapper.getUserById(id);
+        if(user == null || !user.isActive()) {
+            throw new UserNotFoundException();
+        }
+        userMapper.deleteUser(id);
     }
 } 

--- a/src/main/java/com/balanceeat/demo/exception/auth/InvalidPasswordException.java
+++ b/src/main/java/com/balanceeat/demo/exception/auth/InvalidPasswordException.java
@@ -1,0 +1,11 @@
+package com.balanceeat.demo.exception.auth;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class InvalidPasswordException extends RuntimeException {
+    public InvalidPasswordException(String message) {
+        super(message);
+    }
+} 

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -8,6 +8,9 @@
             id,
             email,
             password,
+            profile_image_url,
+            goal_message,
+            is_challenge_enabled,
             nickname,
             birth_year,
             gender,
@@ -20,6 +23,16 @@
             is_active,
             created_at,
             updated_at
+        FROM users
+        WHERE id = #{id} AND is_active = true
+    </select>
+
+    <select id="getUserProfile" parameterType="long" resultType="com.balanceeat.demo.domain.user.dto.UserProfileDTO">
+        SELECT id,
+               email,
+               nickname,
+               profile_image_url AS profileImageUrl,
+               goal_message AS goalMessage
         FROM users
         WHERE id = #{id} AND is_active = true
     </select>
@@ -37,18 +50,13 @@
     <!-- 사용자 정보 수정 -->
     <update id="updateUser" parameterType="com.balanceeat.demo.domain.user.dto.UserDTO">
         UPDATE users 
-        SET password = #{password},
+        SET 
             nickname = #{nickname},
-            birth_year = #{birthYear},
-            gender = #{gender},
-            weight = #{weight},
-            height = #{height},
-            disease_code = #{diseaseCode},
-            diet_habit = #{dietHabit},
-            food_blacklist = #{foodBlacklist},
-            food_preference = #{foodPreference},
+            <if test="newPassword != null and newPassword != ''">
+                password = #{newPassword},
+            </if>
             updated_at = NOW()
-        WHERE id = CAST(#{id} AS SIGNED) AND is_active = true
+        WHERE id = #{id} AND is_active = true
     </update>
     
     <!-- 회원 탈퇴 -->
@@ -56,14 +64,7 @@
         UPDATE users
         SET is_active = false,
             updated_at = NOW()
-        WHERE id = CAST(#{id} AS SIGNED)
-    </update>
-
-    <update id="updateUserIsActive">
-        UPDATE users
-        SET is_active = #{isActive},
-            updated_at = NOW()
-        WHERE id = CAST(#{id} AS SIGNED)
+        WHERE id = #{id}
     </update>
 
     <select id="findByEmail" resultType="com.balanceeat.demo.domain.user.entity.User">
@@ -71,6 +72,9 @@
             id,
             email,
             password,
+            profile_image_url,
+            goal_message,
+            is_challenge_enabled,
             nickname,
             birth_year,
             gender,
@@ -90,7 +94,10 @@
     <insert id="insert" parameterType="com.balanceeat.demo.domain.user.entity.User">
         INSERT INTO users (
             email, 
-            password, 
+            password,
+            profile_image_url,
+            goal_message,
+            is_challenge_enabled,
             nickname,
             birth_year,
             gender,
@@ -105,8 +112,11 @@
             updated_at
         )
         VALUES (
-            #{email}, 
-            #{password}, 
+            #{email},
+            #{password},
+            #{profileImageUrl},
+            #{goalMessage},
+            #{isChallengeEnabled},
             #{nickname},
             #{birthYear},
             #{gender},


### PR DESCRIPTION
## 주요 변경 사항

###  1. DB 스키마 변경
- `users` 테이블에 아래 컬럼 추가
  - `profile_image_url` : 프로필 이미지 URL
  - `goal_message` : 한 줄 목표 메시지
  - `is_challenge_enabled` : 챌린지 참여 여부

### 2. 사용자 프로필 조회 기능 추가
- `UserProfileDTO` 생성
- `GET /user/profile`: 현재 로그인한 유저의 프로필 조회 API
- `GET /user/{id}/profile`: 특정 유저의 프로필 조회 API

### 3. 회원 정보 수정 기능 개선
- `UserDTO`에 `currentPassword`, `newPassword` 필드 추가
- 비밀번호 변경 시 기존 비밀번호 검증 로직 추가
- 새 비밀번호가 있을 경우에만 암호화하여 저장
- `updateUser` 쿼리에 동적 SQL 적용

### 4. 인증 관련
- 비밀번호 불일치 시 `InvalidPasswordException` 발생 → 401 응답

---

## 테스트 방법
- `/user/profile` 호출 시 로그인한 사용자 프로필 정보가 잘 나오는지 확인
- `/user/update`로 닉네임 및 비밀번호 변경 가능 여부 확인
- 잘못된 현재 비밀번호 입력 시 예외 응답 확인

---

## 기타
- `UserMapper`, `UserService`, `UserController` 전체적으로 수정
- 기존 `getUserById(String)` 제거 → `Long` ID로 통일


## 관련 이슈
closes #15 